### PR TITLE
Common gson type adapters

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/util/www/GsonTypeAdapter.java
+++ b/src/gov/usgs/earthquake/nshmp/util/www/GsonTypeAdapter.java
@@ -1,0 +1,42 @@
+package gov.usgs.earthquake.nshmp.util.www;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import gov.usgs.earthquake.nshmp.util.www.enums.ParamType;
+
+/**
+ * Static classes for common Gson {@code TypeAdapter}.
+ * 
+ * @author Peter Powers
+ */
+public class GsonTypeAdapter {
+
+  /** Constrain all doubles to 8 decimal places */
+  public static final class DoubleSerializer implements JsonSerializer<Double> {
+    @Override
+    public JsonElement serialize(
+        Double d, 
+        Type type, 
+        JsonSerializationContext context) {
+      double dOut = Double.valueOf(String.format("%.8g", d));
+      return new JsonPrimitive(dOut);
+    }
+  }
+
+  /** Serialize param type enum as lowercase */
+  public static class ParamTypeSerializer implements JsonSerializer<ParamType> {
+    @Override
+    public JsonElement serialize(
+        ParamType paramType, 
+        Type type, 
+        JsonSerializationContext context) {
+      return new JsonPrimitive(paramType.toLowerCase());
+    }
+  }
+
+}


### PR DESCRIPTION
Resolves #4 

## GsonTypeAdapter.java
* Location: src/gov/usgs/earthquake/nshmp/util/www/GsonTypeAdapter.java
* Taken from :
    - [nshmp-haz-ws/.../meta/Util.java#L87](https://github.com/usgs/nshmp-haz-ws/blob/master/src/gov/usgs/earthquake/nshmp/www/meta/Util.java#L87)
    - [nshmp-haz-ws/.../meta/Util.java#L96](https://github.com/usgs/nshmp-haz-ws/blob/master/src/gov/usgs/earthquake/nshmp/www/meta/Util.java#L96)
* Description: common gson type adapters.